### PR TITLE
Move to sub-domain for astro site property

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import { remarkReadingTime } from "./src/lib/remark-reading-time.mjs";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://cturner8.dev",
+  site: "https://preview.cturner8.dev",
   // TODO: remove this once migrated into main repo
   base: "/jubilant-rotary-phone",
   trailingSlash: "never",


### PR DESCRIPTION
update astro site to sub-domain during initial deployment testing